### PR TITLE
samfirm: fix 403 Client Error: Forbidden

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -168,7 +168,7 @@ const main = async (region: string, model: string): Promise<void> => {
 
   await axios
     .get(
-      `http://cloud-neofussvr.sslcs.cdngc.net/NF_DownloadBinaryForMass.do?file=${binaryModelPath}${binaryFilename}`,
+      `http://cloud-neofussvr.samsungmobile.com/NF_DownloadBinaryForMass.do?file=${binaryModelPath}${binaryFilename}`,
       {
         headers,
         responseType: "stream",


### PR DESCRIPTION
* cloud-neofussvr.sslcs.cdngc.net no longer works for downloading but still works fine for nonce.

* Taken from https://github.com/jesec/SamFirm.NET/commit/c6f6a45285306b0c8e6e2acb738c4110782a6dce